### PR TITLE
New comment on priceup from Matt

### DIFF
--- a/_data/comments/priceup/entry1554233078412-d192a395-a761-4179-a1c5-a5ad8df230fe.json
+++ b/_data/comments/priceup/entry1554233078412-d192a395-a761-4179-a1c5-a5ad8df230fe.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Asher, you're right!  The price is correct in the current beta, so once that version is released as the standard version I think it will be fixed.  Sorry for the confusion!",
+  "email": "3a760317157c33e6b977df8e35ae857d",
+  "name": "Matt",
+  "subdir": "priceup",
+  "_id": "1554233078412-d192a395-a761-4179-a1c5-a5ad8df230fe",
+  "date": 1554233078412
+}


### PR DESCRIPTION
New comment on `priceup`:

```
{
  "name": "Matt",
  "message": "Asher, you're right!  The price is correct in the current beta, so once that version is released as the standard version I think it will be fixed.  Sorry for the confusion!",
  "date": 1554233078412
}
```