### PR TITLE
New comment on apr2020-update from Matt

### DIFF
--- a/_data/comments/apr2020-update/entry1587437569112-v0syg5qps1.json
+++ b/_data/comments/apr2020-update/entry1587437569112-v0syg5qps1.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Whoops!  Thank you for telling me.  It should be fixed now, though if you get a cached version of the page, here's a link: https://github.com/buckets/desktop-beta/releases/tag/v0.56.0",
+  "email": "3a760317157c33e6b977df8e35ae857d",
+  "name": "Matt",
+  "subdir": "apr2020-update",
+  "_id": "1587437569112-v0syg5qps1",
+  "date": 1587437569112
+}


### PR DESCRIPTION
New comment on `apr2020-update`:

```
{
  "name": "Matt",
  "message": "Whoops!  Thank you for telling me.  It should be fixed now, though if you get a cached version of the page, here's a link: https://github.com/buckets/desktop-beta/releases/tag/v0.56.0",
  "date": 1587437569112
}
```